### PR TITLE
Android instructions fixed correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,21 @@ In addition, iOS can open the bluetooth settings and Android can directly enable
 #### Android
 
 1. Open up `android/app/src/main/java/[...]/MainApplication.java`
-  - Add `import com.solinor.bluetoothstatus.RNBluetoothManagerPackage;` to the imports at the top of the file
-  - Add `new RNBluetoothManagerPackage()` to the list returned by the `getPackages()` method
+
+1.1 Add `import com.solinor.bluetoothstatus.RNBluetoothManagerPackage;` to the imports at the top of the file
+
+1.2 Add `new RNBluetoothManagerPackage()` to the list returned by the `getPackages()` method in that file     
+Note: If you add it to the end of the list it should look something like this:
+   ```
+    @Override
+    protected List<ReactPackage> getPackages() {
+      return Arrays.<ReactPackage>asList(
+          new MainReactPackage(),         // Note the addtional comma needed for the original last item in the list
+          new RNBluetoothManagerPackage() // For https://github.com/solinor/react-native-bluetooth-status
+      );
+    }
+   ```
+
 2. Append the following lines to `android/settings.gradle`:
   	```
   	include ':react-native-bluetooth-status'


### PR DESCRIPTION
Previewed changes and they look ok now. 

See the NPM page: https://www.npmjs.com/package/react-native-bluetooth-status

The numbers on the NPM readme page on Chrome were coming out incorrectly, although they are OK on github.  
I checked the history of the file and this was never changed so it is an issue.  

Instead of 1, two indented bullets and then 2 and 3, it has: 1, two main bullets BEFORE the numbers , then again 1 and 2. 

I fixed that by inserting the numbers manually. Note 4 spaces at end of one of the lines, for a line-break. 

I also gave an example of how to add the packages to the `getPackage()` list, noting the needed comma.