### PR TITLE
Remove callback to open iOS Settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ For further usage examples, see the [example project](examples/ManagerTest/) usi
 | **state** | Returns a promise, which will return a boolean value, `true` if bluetooth is enabled, `false` if disabled.                                                                                                                                                                                                                                                                                                            |
 | **enable**    | **Android only** Changes bluetooth state. Takes boolean parameter (defaults to true), `true` to enable, `false` to disable. Returns a promise, which returns whether the change was successful or not.           |
 | **disable**    | **Android only** Disables bluetooth, same end result as calling `enable(false)`. Returns a promise, which returns whether the change was successful or not.           |
-| **openBluetoothSettings**    | **iOS only** Open OS Settings directly to bluetooth settings, recommended to use from Alert dialog, where user decides to change bluetooth state.            |
 
 #### Thanks
 

--- a/examples/ManagerTest/index.ios.js
+++ b/examples/ManagerTest/index.ios.js
@@ -53,8 +53,7 @@ export default class ManagerTest extends Component {
 
   requireBluetooth() {
     Alert.alert('bt required', 'much required',
-      [{ text: 'Settings', onPress: () => BluetoothStatus.openBluetoothSettings() },
-       { text: 'Cancel', onPress: () => {} }],
+      [{ text: 'Cancel', onPress: () => {} }],
        { cancelable: false }
     );
   }

--- a/index.js
+++ b/index.js
@@ -73,13 +73,6 @@ class BluetoothManager {
   async disable() {
     return this.enable(false);
   };
-
-  openBluetoothSettings() {
-    if (Platform.OS === 'ios') {
-      RNBluetoothManager.openBluetoothSettings(() => {
-      })
-    }
-  }
 }
 
 export let BluetoothStatus = new BluetoothManager();

--- a/ios/RNBluetoothManager.m
+++ b/ios/RNBluetoothManager.m
@@ -61,15 +61,5 @@ RCT_EXPORT_METHOD(initialize) {
     [self sendEventWithName:@"bluetoothStatus" body:stateName];
 }
 
-RCT_EXPORT_METHOD(openBluetoothSettings:(RCTResponseSenderBlock)callback) {
-    NSLog(@"iOS: trying to open settings");
-    if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"10.0")) {
-        [[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"App-Prefs:root=Bluetooth"]];
-    } else {
-        [[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"prefs:root=Bluetooth"]];
-    }
-    callback(@[[NSNull null]]);
-}
-
 - (NSArray<NSString *> *)supportedEvents { return @[@"bluetoothStatus"]; }
 @end


### PR DESCRIPTION
This functionality has since transitioned to a private API and is leading to AppStore rejections. As noted by their documentation opening settings should can only be limited to the application specific settings.

Reference:

https://developer.apple.com/documentation/uikit/uiapplicationopensettingsurlstring?language=objc