### PR TITLE
Improve iOS Message Passing

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,16 +8,13 @@ const { RNBluetoothManager } = NativeModules;
 class BluetoothManager {
 
   subscription: mixed;
-  subscriber: Function;
+  bluetoothState: 'unknown' | 'resetting' | 'unsupported' | 'unauthorized' |'off' | 'on' | 'unknown';
 
   constructor() {
     const bluetoothEvent = new NativeEventEmitter(RNBluetoothManager);
-    this.subscription = bluetoothEvent.addListener('bluetoothStatus', (...args) => {
-        this.subscriber(this, args);
-      }
-    );
-    this.subscriber = () => {
-    }
+    this.subscription = bluetoothEvent.addListener('bluetoothStatus', (state) => {
+      this.bluetoothState = state;
+    });
   }
 
   async state() {
@@ -31,15 +28,7 @@ class BluetoothManager {
           resolve(status);
         });
       } else if (Platform.OS === 'ios') {
-        this.subscriber = (manager, responseArray) => {
-          let bluetoothState = responseArray[0];
-          if (bluetoothState !== 'on' && bluetoothState !== 'off') {
-            return;
-          }
-          this.subscriber = () => {};
-          resolve(bluetoothState === 'on');
-        };
-        RNBluetoothManager.initialize();
+        resolve(this.bluetoothState === 'on');
       }
     });
   };

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 import { Platform } from 'react-native'
 import { NativeModules, DeviceEventEmitter, NativeEventEmitter} from 'react-native'
+import waitUntil from 'wait-until'
 
 const { RNBluetoothManager } = NativeModules;
 
@@ -28,7 +29,15 @@ class BluetoothManager {
           resolve(status);
         });
       } else if (Platform.OS === 'ios') {
-        resolve(this.bluetoothState === 'on');
+        waitUntil()
+          .interval(100)
+          .times(10)
+          .condition(() => {
+            return this.bluetoothState !== undefined
+          })
+          .done(() => {
+            resolve(this.bluetoothState === 'on');
+          })
       }
     });
   };

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 import { Platform } from 'react-native'
 import { NativeModules, DeviceEventEmitter, NativeEventEmitter} from 'react-native'
-import waitUntil from 'wait-until'
+import waitUntil from '@cs125/wait-until'
 
 const { RNBluetoothManager } = NativeModules;
 

--- a/ios/RNBluetoothManager.m
+++ b/ios/RNBluetoothManager.m
@@ -15,6 +15,10 @@
 
 
 @implementation RNBluetoothManager
+{
+    bool hasListeners;
+    NSString *stateName;
+}
 
 #pragma mark Initialization
 
@@ -23,8 +27,13 @@
     if (self = [super init]) {
         self.centralManager = [[CBCentralManager alloc] initWithDelegate:self queue:dispatch_get_main_queue() options:[NSDictionary dictionaryWithObject:[NSNumber numberWithInt:0] forKey:CBCentralManagerOptionShowPowerAlertKey]];
     }
-    
+
     return self;
+}
+
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
 }
 
 RCT_EXPORT_MODULE();
@@ -51,15 +60,29 @@ RCT_EXPORT_METHOD(initialize) {
         default:
             return @"unknown";
     }
-    
+
     return @"unknown";
+}
+
+-(void)startObserving {
+    hasListeners = YES;
+    NSLog(@"startObserving %@", stateName);
+    [self sendEventWithName:@"bluetoothStatus" body:stateName];
+}
+
+-(void)stopObserving {
+    hasListeners = NO;
 }
 
 - (void)centralManagerDidUpdateState:(CBCentralManager *)central
 {
-    NSString *stateName = [self centralManagerStateToString:central.state];
-    [self sendEventWithName:@"bluetoothStatus" body:stateName];
+    stateName = [self centralManagerStateToString:central.state];
+    if (hasListeners) {
+        [self sendEventWithName:@"bluetoothStatus" body:stateName];
+    }
 }
 
 - (NSArray<NSString *> *)supportedEvents { return @[@"bluetoothStatus"]; }
 @end
+
+

--- a/ios/RNBluetoothManager.m
+++ b/ios/RNBluetoothManager.m
@@ -66,7 +66,6 @@ RCT_EXPORT_METHOD(initialize) {
 
 -(void)startObserving {
     hasListeners = YES;
-    NSLog(@"startObserving %@", stateName);
     [self sendEventWithName:@"bluetoothStatus" body:stateName];
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,11 @@
+{
+  "name": "react-native-bluetooth-status",
+  "version": "1.1.3",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "wait-until": {
+      "version": "file:../wait-until"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cs125/react-native-bluetooth-status",
-  "version": "1.1.4",
+  "version": "1.1.4.1",
   "description": "React-Native library to query and manage bluetooth state of the device (iOS and Android)",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cs125/react-native-bluetooth-status",
-  "version": "1.1.4.1",
+  "version": "1.1.5",
   "description": "React-Native library to query and manage bluetooth state of the device (iOS and Android)",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "react-native-bluetooth-status",
-  "version": "1.1.3",
+  "name": "@cs125/react-native-bluetooth-status",
+  "version": "1.1.4",
   "description": "React-Native library to query and manage bluetooth state of the device (iOS and Android)",
   "main": "index.js",
   "scripts": {
@@ -15,12 +15,12 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git@github.com:solinor/react-native-bluetooth-status.git"
+    "url": "git@github.com:cs125-illinois/react-native-bluetooth-status.git"
   },
   "bugs": {
-    "url": "https://github.com/solinor/react-native-bluetooth-status/issues"
+    "url": "https://github.com/cs125-illinois/react-native-bluetooth-status/issues"
   },
-  "homepage": "https://github.com/solinor/react-native-bluetooth-status#readme",
+  "homepage": "https://github.com/cs125-illinois/react-native-bluetooth-status#readme",
   "directories": {
     "example": "examples"
   },
@@ -34,5 +34,8 @@
     "react": "16.0.0-alpha.6",
     "react-native": "^0.44.1",
     "flow-bin": "^0.44.2"
+  },
+  "dependencies": {
+    "@cs125/wait-until": "^0.0.3"
   }
 }


### PR DESCRIPTION
Several changes were made to quiet recent React Native warnings, including adding `requiresMainQueueSetup` and handling empty listener cases.

More importantly, a race condition was preventing the module from working on iOS. If `centralManagerDidUpdateState` was called before the JavaScript code could set up a listener the first state update was missed. I've refactored things so that the JavaScript code uses a persistent listener and added state caching to the iOS code to ensure that the current state is delivered any time a new subscription is added.