### PR TITLE
manual init on get state for iOS

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ const { RNBluetoothManager } = NativeModules;
 const BT_STATUS_EVENT = "bluetoothStatus";
 class BluetoothManager {
   subscription: mixed;
+  inited: boolean;
   bluetoothState:
     | "unknown"
     | "resetting"
@@ -43,6 +44,7 @@ class BluetoothManager {
   }
 
   async state() {
+    this.manualInit()
     return new Promise((resolve, reject) => {
       waitUntil()
         .interval(100)
@@ -56,6 +58,13 @@ class BluetoothManager {
     });
   }
 
+  manualInit() {
+    if(!this.inited) {
+      RNBluetoothManager.manualInitialization()
+    }
+    this.inited = true
+  }
+  
   enable(enabled: boolean = true) {
     if (Platform.OS === "android") {
       RNBluetoothManager.setBluetoothState(enabled);

--- a/index.js
+++ b/index.js
@@ -59,10 +59,12 @@ class BluetoothManager {
   }
 
   manualInit() {
-    if(!this.inited) {
-      RNBluetoothManager.manualInitialization()
+    if (Platform.OS === "ios") {
+      if(!this.inited) {
+        RNBluetoothManager.manualInitialization()
+      }
+      this.inited = true
     }
-    this.inited = true
   }
   
   enable(enabled: boolean = true) {

--- a/ios/RNBluetoothManager.m
+++ b/ios/RNBluetoothManager.m
@@ -22,16 +22,15 @@
 
 #pragma mark Initialization
 
-- (instancetype)init
+- (instancetype)manualInit
 {
-    if (self = [super init]) {
-        self.centralManager = [[CBCentralManager alloc] initWithDelegate:self queue:dispatch_get_main_queue() options:[NSDictionary dictionaryWithObject:[NSNumber numberWithInt:0] forKey:CBCentralManagerOptionShowPowerAlertKey]];
-    }
-
+    NSDictionary *options = @{CBCentralManagerOptionShowPowerAlertKey: @NO};
+    self.centralManager = [[CBCentralManager alloc] initWithDelegate:self queue:nil options:options];
+    
     return self;
 }
 
-+ (BOOL)requiresMainQueueSetup
++ (BOOL) requiresMainQueueSetup
 {
     return YES;
 }
@@ -40,6 +39,10 @@ RCT_EXPORT_MODULE();
 
 RCT_EXPORT_METHOD(initialize) {
     [self centralManagerDidUpdateState:self.centralManager];
+}
+
+RCT_EXPORT_METHOD(manualInitialization) {
+    [self manualInit];
 }
 
 - (NSString *) centralManagerStateToString: (int)state


### PR DESCRIPTION
On start with iOS, app always tried to get BT permissions on it launch, now they will requesting only once, on first **state** call