### PR TITLE
Register broadcast receiver on resume

### DIFF
--- a/android/src/main/java/com/solinor/bluetoothstatus/RNBluetoothManagerModule.java
+++ b/android/src/main/java/com/solinor/bluetoothstatus/RNBluetoothManagerModule.java
@@ -61,13 +61,17 @@ public class RNBluetoothManagerModule extends ReactContextBaseJavaModule impleme
         }
     };
 
+    private void registerBroadcastReceiver() {
+        IntentFilter filter = new IntentFilter(BluetoothAdapter.ACTION_STATE_CHANGED);
+        reactContext.registerReceiver(receiver, filter);
+    }
+
     public RNBluetoothManagerModule(ReactApplicationContext reactContext) {
         super(reactContext);
         this.reactContext = reactContext;
         reactContext.addLifecycleEventListener(this);
         btAdapter = BluetoothAdapter.getDefaultAdapter();
-        IntentFilter filter = new IntentFilter(BluetoothAdapter.ACTION_STATE_CHANGED);
-        reactContext.registerReceiver(receiver, filter);
+        registerBroadcastReceiver();
     }
 
     @Override
@@ -97,6 +101,7 @@ public class RNBluetoothManagerModule extends ReactContextBaseJavaModule impleme
 
     @Override
     public void onHostResume() {
+        registerBroadcastReceiver();
         Handler handler = new Handler();
         handler.postDelayed(new Runnable() {
             @Override


### PR DESCRIPTION
This should fix the "Receiver not registered" problem by registering the receiver again when the activity is resumed.

Tested on a real Android phone and it seems to get rid of the crash when closing the app with the back button.

Closes #48 