### PR TITLE
Fix for calling getJSModule too early

### DIFF
--- a/android/src/main/java/com/solinor/bluetoothstatus/RNBluetoothManagerModule.java
+++ b/android/src/main/java/com/solinor/bluetoothstatus/RNBluetoothManagerModule.java
@@ -34,6 +34,10 @@ public class RNBluetoothManagerModule extends ReactContextBaseJavaModule impleme
     private void sendEvent(ReactContext reactContext,
                            String eventName,
                            @Nullable WritableMap params) {
+        if (!reactContext.hasActiveCatalystInstance()) {
+            return;
+        }
+
         reactContext
                 .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
                 .emit(eventName, params);


### PR DESCRIPTION
We've seen a few crashes in our production app where this library was calling into the JS module before the react instance was fully initialized. This PR adds a quick check to make sure that the react context is ready to be accessed by the library. 

Stack trace from one of our crashes:

```
Caused by java.lang.IllegalStateException: Tried to access a JS module before the React instance was fully set up. Calls to ReactContext#getJSModule should only happen once initialize() has been called on your native module.
       at com.facebook.react.bridge.ReactContext.getJSModule(ReactContext.java:148)
       at com.solinor.bluetoothstatus.RNBluetoothManagerModule.sendEvent(RNBluetoothManagerModule.java:38)
       at com.solinor.bluetoothstatus.RNBluetoothManagerModule.access$100(RNBluetoothManagerModule.java:22)
       at com.solinor.bluetoothstatus.RNBluetoothManagerModule$1.onReceive(RNBluetoothManagerModule.java:57)
```