### PR TITLE
Fix: RN >= v0.65 Listener warnings

### DIFF
--- a/android/src/main/java/com/solinor/bluetoothstatus/RNBluetoothManagerModule.java
+++ b/android/src/main/java/com/solinor/bluetoothstatus/RNBluetoothManagerModule.java
@@ -124,4 +124,14 @@ public class RNBluetoothManagerModule extends ReactContextBaseJavaModule impleme
     public void onHostDestroy() {
         reactContext.unregisterReceiver(receiver);
     }
+
+    @ReactMethod
+    public void addListener(String eventName) {
+      // Keep: Required for RN built in Event Emitter Calls.
+    }
+
+    @ReactMethod
+    public void removeListeners(int count) {
+      // Keep: Required for RN built in Event Emitter Calls.
+    }
 }


### PR DESCRIPTION
Fix for warnings below

WARN new NativeEventEmitter() was called with a non-null argument without the required addListener method.
WARN new NativeEventEmitter() was called with a non-null argument without the required removeListeners method.

on Android from react-native 0.65 and higher versions